### PR TITLE
updated run.sh to use crawler ready arguments and added chrome 67 deb

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,33 @@ mkdir ~/.config/
 mkdir ~/.config/google-chrome
 touch ~/.config/google-chrome/First\ Run
 
-run_browser google-chrome --no-default-browser-check --disable-popup-blocking --disable-background-networking --disable-client-side-phishing-detection --disable-component-update --safebrowsing-disable-auto-update "$URL" &
+# tunnel to localhost
+run_browser socat tcp-listen:9222,fork tcp:localhost:9221 &
+
+run_browser google-chrome --no-default-browser-check \
+  --disable-component-update \
+  --disable-popup-blocking \
+  --disable-background-networking \
+  --disable-background-timer-throttling \
+  --disable-client-side-phishing-detection \
+  --disable-default-apps \
+  --disable-extensions \
+  --disable-hang-monitor \
+  --disable-prompt-on-repost \
+  --disable-sync \
+  --disable-translate \
+  --disable-domain-reliability \
+  --disable-renderer-backgrounding \
+  --disable-infobars \
+  --disable-translate \
+  --metrics-recording-only \
+  --no-first-run \
+  --safebrowsing-disable-auto-update \
+  --password-store=basic \
+  --use-mock-keychain \
+  --autoplay-policy=no-user-gesture-required  \
+  --disable-features=site-per-process \
+  --remote-debugging-port=9221 "$URL" &
 
 pid=$!
 


### PR DESCRIPTION
This PR updates run.sh with defaults that allow efficient usage of Chrome as a web crawler.
For more information about the flags can be found at
- [webrecorder/simplechrome default args](https://github.com/webrecorder/simplechrome/blob/935effd6c38cab2988784dd5d150788923ea0367/simplechrome/launcher.py#L28)

This PR also adds an updated chrome deb (v67) file to be used alongside the updated run.sh configuration.
  
 