### PR TITLE
Add Chrome 73

### DIFF
--- a/deb/google-chrome-stable_73.0.3683.75-1_amd64.deb
+++ b/deb/google-chrome-stable_73.0.3683.75-1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f836849aa4dffce513d5e2b0baff1b632b05495f6659c3bdf5370e6750184982
+size 57711706

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,14 @@ services:
         labels:
             "wr.version": "67"
             "wr.release": "2018-05-29"
+
+   chrome_73:
+     image: 'oldwebtoday/chrome:73'
+     build:
+       context: .
+       args:
+         CHROME_DEB: google-chrome-stable_73.0.3683.75-1_amd64.deb
+
+       labels:
+         "wr.version": "73"
+         "wr.release": "2019-03-12"


### PR DESCRIPTION
This PR adds google-chrome-73.0.3683.75-1 to the list of available chrome browsers.
This PR also modifies the default arguments list used when launching the browser in order to ensure that if we are using chrome v70+ we can properly use it

Full details of the new arguments can be found at https://peter.sh/experiments/chromium-command-line-switches/

But a brief summation of what they do is a follows

We ensure that no window can get backgrounded if it becomes occluded 
No tab/window that takes up a lot memory starts visually blinking
The gpu process can be restarted as many times as needed while the window(s)/tab(s) are still alive
No hyperlink auditing pings
If a screenshot is taken it looks as it should
No renderer process is killed if it is sending alot of messages 
If lazy frame and or image loading is enabled it is disabled
The networkservice used by the browser is not run out of process  
We allow hidden media elements to play (this will allow older web pages that utilize this to behave properly)