### PR TITLE
Improved launch arguments for user profiles

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -50,7 +50,6 @@ fi
 run_forever google-chrome --no-default-browser-check \
   ${HEADLESS} ${CARGS} \
   --allow-hidden-media-playback \
-  --disable-component-update \
   --disable-popup-blocking \
   --disable-background-networking \
   --disable-background-timer-throttling \
@@ -59,8 +58,6 @@ run_forever google-chrome --no-default-browser-check \
   --disable-extensions \
   --disable-hang-monitor \
   --disable-prompt-on-repost \
-  --disable-sync \
-  --disable-translate \
   --disable-domain-reliability \
   --disable-renderer-backgrounding \
   --disable-infobars \
@@ -68,8 +65,6 @@ run_forever google-chrome --no-default-browser-check \
   --metrics-recording-only \
   --no-first-run \
   --safebrowsing-disable-auto-update \
-  --password-store=basic \
-  --use-mock-keychain \
   --autoplay-policy=no-user-gesture-required  \
   --remote-debugging-port=9221 "$URL" &
 


### PR DESCRIPTION
removed duplicate --disable-translate switch
removed --disable-sync, --password-store=basic, and --use-mock-keychain in order to allow user profile syncing and to let chrome choose the best password saving mechanism
removed --disable-component-update in order to allow chrome to update some of its components, especially those pertaining to user profiles